### PR TITLE
Set permissions for SELinux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - "8200:8200"
     volumes:
-      - ./tools/wait-for-it.sh:/wait-for-it.sh
-      - ./config/vault:/config
-      - ./config/vault/policies:/policies
+      - ./tools/wait-for-it.sh:/wait-for-it.sh:z
+      - ./config/vault:/config:z
+      - ./config/vault/policies:/policies:z
     entrypoint: /wait-for-it.sh -t 20 -h consul -p 8500 -s -- vault server -config=/config/with-consul.hcl


### PR DESCRIPTION
The `:z` at the end of the volumes makes it work in SELinux.
This instructs Docker/SELinux to apply the correct labels so that it
works with multiple containers accessing the same files.